### PR TITLE
fix: remove unused scrollPosition state variable

### DIFF
--- a/src/pages/Home.js
+++ b/src/pages/Home.js
@@ -19,7 +19,6 @@ const Home = () => {
   const [hasMore, setHasMore] = useState(savedState?.hasMore ?? true);
   const [totalResults, setTotalResults] = useState(savedState?.totalResults || 0);
   const [filters, setFilters] = useState(savedState?.filters || { type: '', year: '' });
-  const [scrollPosition, setScrollPosition] = useState(savedState?.scrollPosition || 0);
   
   const observer = useRef();
   const lastMovieRef = useCallback(node => {


### PR DESCRIPTION
- Remove unused scrollPosition and setScrollPosition state
- Fix ESLint no-unused-vars error in CI build
- Scroll position is accessed directly from savedState when needed